### PR TITLE
Made get_boto3_body an instance method

### DIFF
--- a/src/basicbedrock/basicbedrock.py
+++ b/src/basicbedrock/basicbedrock.py
@@ -159,8 +159,7 @@ class BasicBedrock(object):
                 j = json.dumps(json.loads(j), indent=indent)
         print(j)
 
-    @staticmethod
-    def get_boto3_body(model_id: str, prompt: str) -> str:
+    def get_boto3_body(self, model_id: str, prompt: str) -> str:
         """
         given a model_id and a prompt, this will construct the boto3 'body' parameter using the specified prompt and params,
         but it will not invoke bedrock or pass it to boto3, it will simply return the boto3 'body' param as a string.


### PR DESCRIPTION
`get_boto3_body` is a static method but attempts to reference instance variable `self.params`. This is causing an error for me in a codebase that was working with previous versions of `BasicBeadrock`:

```
File "/*/venv/lib/python3.9/site-packages/basicbedrock/basicbedrock.py", line 180, in get_boto3_body
  schema_inst.set_params(self.params)
NameError: name 'self' is not defined
```

This PR fixed this by making `get_boto3_body` an instance method and passing in `self`.